### PR TITLE
Do not exit with error when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "git+ssh://git@github.com:scotttesler/logurt.git"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": ""
   },
   "version": "1.1.0"
 }


### PR DESCRIPTION
TravisCI's build fails (and thus the new version is not published to NPM) because `npm run test` is currently raising an error.

[Example of failing build](https://travis-ci.org/scotttesler/logurt/builds/433247427).

---

The changes on this branch result in [a successful build](https://travis-ci.org/scotttesler/logurt/builds/433249344).